### PR TITLE
Supports STS token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Supports STS token (#12).
+
 ## [1.0.0] - 2023-12-04
 
 ### Added

--- a/src/Middlewares/ConfigureMetadata.php
+++ b/src/Middlewares/ConfigureMetadata.php
@@ -15,14 +15,21 @@ class ConfigureMetadata
      */
     public static function make(Tablestore $tablestore): callable
     {
-        return Middleware::mapRequest(fn (RequestInterface $request): RequestInterface => $request
-            ->withHeader('x-ots-accesskeyid', $tablestore->accessKeyId())
-            ->withHeader('x-ots-apiversion', '2015-12-31')
-            ->withHeader('x-ots-contentmd5', base64_encode(
-                md5($request->getBody()->getContents(), binary: true)
-            ))
-            ->withHeader('x-ots-date', gmdate('Y-m-d\\TH:i:s.v\\Z'))
-            ->withHeader('x-ots-instancename', $tablestore->instanceName())
-        );
+        return Middleware::mapRequest(function (RequestInterface $request) use ($tablestore): RequestInterface {
+            $request = $request
+                ->withHeader('x-ots-accesskeyid', $tablestore->accessKeyId())
+                ->withHeader('x-ots-apiversion', '2015-12-31')
+                ->withHeader('x-ots-contentmd5', base64_encode(
+                    md5($request->getBody()->getContents(), binary: true)
+                ))
+                ->withHeader('x-ots-date', gmdate('Y-m-d\\TH:i:s.v\\Z'))
+                ->withHeader('x-ots-instancename', $tablestore->instanceName());
+
+            if (is_string($tablestore->token())) {
+                return $request->withHeader('x-ots-ststoken', $tablestore->token());
+            }
+
+            return $request;
+        });
     }
 }

--- a/src/Tablestore.php
+++ b/src/Tablestore.php
@@ -25,6 +25,11 @@ class Tablestore
     protected string $instance;
 
     /**
+     * The STS token for the access key.
+     */
+    protected string $token;
+
+    /**
      * Create a Tablestore.
      */
     public function __construct(
@@ -66,6 +71,24 @@ class Tablestore
     public function instanceName(): string
     {
         return $this->instance;
+    }
+
+    /**
+     * The STS token for the access key.
+     */
+    public function token(): ?string
+    {
+        return $this->token ?? null;
+    }
+
+    /**
+     * Configure STS token for the access key.
+     */
+    public function tokenUsing(string $token): self
+    {
+        $this->token = $token;
+
+        return $this;
     }
 
     /**

--- a/tests/ConfigureMetadataTest.php
+++ b/tests/ConfigureMetadataTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Dew\Tablestore\Middlewares\ConfigureMetadata;
+use Dew\Tablestore\Tablestore;
+use GuzzleHttp\Psr7\Request;
+
+test('headers are sorted', function ($ots) {
+    $apply = ConfigureMetadata::make($ots);
+    $request = $apply(fn ($request, $options) => $request)(new Request('GET', '/'), []);
+    $sorted = array_keys($request->getHeaders());
+    sort($sorted);
+    expect(array_keys($request->getHeaders()))->toBe($sorted);
+})->with('tablestore instances');
+
+test('header sts token is missing when not provided', function () {
+    $ots = new Tablestore('key', 'secret', 'https://instance.cn-hangzhou.ots.aliyuncs.com');
+    $apply = ConfigureMetadata::make($ots);
+    $request = $apply(fn ($request, $options) => $request)(new Request('GET', '/'), []);
+    expect($request->hasHeader('x-ots-ststoken'))->toBeFalse();
+});
+
+test('header has sts token when provided', function () {
+    $ots = new Tablestore('key', 'secret', 'https://instance.cn-hangzhou.ots.aliyuncs.com');
+    $ots->tokenUsing('token');
+    $apply = ConfigureMetadata::make($ots);
+    $request = $apply(fn ($request, $options) => $request)(new Request('GET', '/'), []);
+    expect($request->hasHeader('x-ots-ststoken'))->toBeTrue()
+        ->and($request->getHeaderLine('x-ots-ststoken'))->toBe('token');
+});
+
+dataset('tablestore instances', [
+    'regular' => [
+        new Tablestore('key', 'secret', 'https://instance.cn-hangzhou.ots.aliyuncs.com'),
+    ],
+    'with sts token' => [
+        (new Tablestore('key', 'secret', 'https://instance.cn-hangzhou.ots.aliyuncs.com'))
+            ->tokenUsing('token'),
+    ],
+]);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -95,10 +95,18 @@ function integrationTestEnabled(): bool
  */
 function tablestore(): Tablestore
 {
-    return new Tablestore(
+    $tablestore = new Tablestore(
         getenv('ACS_ACCESS_KEY_ID'), getenv('ACS_ACCESS_KEY_SECRET'),
         getenv('TS_ENDPOINT'), getenv('TS_INSTNACE')
     );
+
+    $token = getenv('ACS_STS_TOKEN');
+
+    if (is_string($token) && $token !== '') {
+        $tablestore->tokenUsing($token);
+    }
+
+    return $tablestore;
 }
 
 /**


### PR DESCRIPTION
Added a test to make sure that the metadata headers are sorted, even though the signature calculation is responsible for sorting the headers, but it could save us a little execution time over and over again since the metadata headers are not updated very often.