### PR TITLE
Table existence check

### DIFF
--- a/src/Schema/SchemaHandler.php
+++ b/src/Schema/SchemaHandler.php
@@ -3,6 +3,7 @@
 namespace Dew\Tablestore\Schema;
 
 use Dew\Tablestore\Concerns\InteractsWithRequest;
+use Dew\Tablestore\Exceptions\TablestoreException;
 use Dew\Tablestore\Tablestore;
 use InvalidArgumentException;
 use Protos\CreateTableRequest;
@@ -57,6 +58,24 @@ class SchemaHandler
         $response->mergeFromString($this->send('/DescribeTable', $request));
 
         return $response;
+    }
+
+    /**
+     * Determine whether the table exists.
+     */
+    public function hasTable(string $table): bool
+    {
+        try {
+            $this->getTable($table);
+
+            return true;
+        } catch (TablestoreException $e) {
+            if ($e->getError()->getCode() === 'OTSObjectNotExist') {
+                return false;
+            }
+
+            throw $e;
+        }
     }
 
     /**

--- a/src/Tablestore.php
+++ b/src/Tablestore.php
@@ -122,6 +122,14 @@ class Tablestore
     }
 
     /**
+     * Determine whether the table exists.
+     */
+    public function hasTable(string $table): bool
+    {
+        return (new SchemaHandler($this))->hasTable($table);
+    }
+
+    /**
      * Create a new table.
      *
      * @param  callable(\Dew\Tablestore\Schema\Blueprint): void  $callback

--- a/tests/Integration/TableTest.php
+++ b/tests/Integration/TableTest.php
@@ -3,12 +3,15 @@
 use Dew\Tablestore\Schema\Blueprint;
 
 test('table can be created and deleted', function () {
+    expect(tablestore()->hasTable('testing'))->toBeFalse();
+
     tablestore()->createTable('testing', function (Blueprint $table) {
         $table->string('key')->primary();
-        $table->encryptWithKms();
     });
+    expect(tablestore()->hasTable('testing'))->toBeTrue();
 
     tablestore()->deleteTable('testing');
+    expect(tablestore()->hasTable('testing'))->toBeFalse();
 })->skip(! integrationTestEnabled(), 'integration test not enabled');
 
 test('list lists all the tables', function () {


### PR DESCRIPTION
The **hasTable** interface makes use of the **DescribeTable** API and returns true if the information of the table was retrieved successfully:

```php
$tablestore->hasTable('entries');
```