### PR TITLE
Tablestore instance management API

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,7 @@
         <env name="INTEGRATION_TEST_ENABLED" value="false"/>
         <env name="ACS_ACCESS_KEY_ID" value=""/>
         <env name="ACS_ACCESS_KEY_SECRET" value=""/>
+        <env name="ACS_DEFAULT_REGION" value="us-west-1"/>
         <env name="TS_ENDPOINT" value=""/>
         <env name="TS_INSTANCE" value=""/>
     </php>

--- a/src/AcsSignature.php
+++ b/src/AcsSignature.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Dew\Tablestore;
+
+use Dew\Tablestore\Contracts\BuildsSignature;
+use GuzzleHttp\Psr7\Query;
+use Psr\Http\Message\RequestInterface;
+
+class AcsSignature implements BuildsSignature
+{
+    /**
+     * The headers should be included in signature calculation.
+     *
+     * @var string[]
+     */
+    public array $whitelist = [];
+
+    /**
+     * Create a Tablestore signature builder.
+     */
+    public function __construct(
+        protected string $key
+    ) {
+        //
+    }
+
+    /**
+     * The algorithm in ACS format.
+     */
+    public function algorithmForAcs(): string
+    {
+        return 'ACS3-HMAC-SHA256';
+    }
+
+    /**
+     * The algorithm.
+     */
+    public function algorithm(): string
+    {
+        return 'sha256';
+    }
+
+    /**
+     * Get the headers for signature calculation.
+     *
+     * @return  string[]
+     */
+    public function signedHeaders(RequestInterface $request): array
+    {
+        $signed = [];
+
+        foreach (array_keys($request->getHeaders()) as $header) {
+            $header = strtolower($header);
+
+            if ($this->isMetadata($header) || $this->isInWhitelist($header)) {
+                $signed[] = $header;
+            }
+        }
+
+        sort($signed);
+
+        return $signed;
+    }
+
+    /**
+     * Determine if the header is an ACS metadata.
+     */
+    public function isMetadata(string $header): bool
+    {
+        return str_starts_with($header, 'x-acs-');
+    }
+
+    /**
+     * Determine if the header is in signature whitelist.
+     */
+    public function isInWhitelist(string $header): bool
+    {
+        return in_array($header, $this->whitelist, strict: true);
+    }
+
+    /**
+     * Include the headers to signature calculation.
+     *
+     * @param  string[]  $headers
+     */
+    public function include(array $headers): self
+    {
+        $this->whitelist = $headers;
+
+        return $this;
+    }
+
+    /**
+     * Build the signature for the given request.
+     */
+    public function build(RequestInterface $request): string
+    {
+        $headers = $this->signedHeaders($request);
+
+        $data = implode("\n", [
+            $request->getMethod(),
+            $request->getUri()->getPath(),
+            $this->sortedQuery($request->getUri()->getQuery()),
+            implode("\n", array_map(fn ($name): string => sprintf('%s:%s',
+                $name, $request->getHeaderLine($name)
+            ), $headers)),
+            '',
+            implode(';', $headers),
+            hash('sha256', $request->getBody()->getContents()),
+        ]);
+
+        $data = implode("\n", [
+            $this->algorithmForAcs(),
+            hash('sha256', $data),
+        ]);
+
+        return hash_hmac($this->algorithm(), $data, $this->key);
+    }
+
+    /**
+     * Get the sorted query string.
+     */
+    protected function sortedQuery(string $query): string
+    {
+        $parsed = Query::parse($query);
+
+        ksort($parsed);
+
+        return Query::build($parsed);
+    }
+}

--- a/src/Concerns/CommunicatesWithAcs.php
+++ b/src/Concerns/CommunicatesWithAcs.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Dew\Tablestore\Concerns;
+
+use Dew\Tablestore\Contracts\BuildsSignature;
+
+trait CommunicatesWithAcs
+{
+    /**
+     * The ACS access key ID.
+     */
+    protected string $accessKeyId;
+
+    /**
+     * The ACS access key secret.
+     */
+    protected string $accessKeySecret;
+
+    /**
+     * The service endpoint.
+     */
+    protected string $endpoint;
+
+    /**
+     * The signature builder.
+     */
+    protected BuildsSignature $signature;
+
+    /**
+     * The STS token for the access key.
+     */
+    protected string $token;
+
+    /**
+     * The HTTP request options.
+     *
+     * @var array<string, mixed>
+     */
+    protected array $options = [];
+
+    /**
+     * The ACS access key ID.
+     */
+    public function accessKeyId(): string
+    {
+        return $this->accessKeyId;
+    }
+
+    /**
+     * The ACS access key secret.
+     */
+    public function accessKeySecret(): string
+    {
+        return $this->accessKeySecret;
+    }
+
+    /**
+     * The STS token for the access key.
+     */
+    public function token(): ?string
+    {
+        return $this->token ?? null;
+    }
+
+    /**
+     * Configure STS token for the access key.
+     */
+    public function tokenUsing(string $token): self
+    {
+        $this->token = $token;
+
+        return $this;
+    }
+
+    /**
+     * The service endpoint.
+     */
+    public function endpoint(): string
+    {
+        return $this->endpoint;
+    }
+
+    /**
+     * The signature builder.
+     */
+    public function signature(): BuildsSignature
+    {
+        return $this->signature ??= $this->newSignature();
+    }
+
+    /**
+     * Create a new signature builder.
+     */
+    abstract protected function newSignature(): BuildsSignature;
+
+    /**
+     * Set signature builder.
+     */
+    public function signatureUsing(BuildsSignature $signature): self
+    {
+        $this->signature = $signature;
+
+        return $this;
+    }
+
+    /**
+     * The HTTP request options.
+     *
+     * @return array<string, mixed>
+     */
+    public function options(): array
+    {
+        $default = [
+            'timeout' => 2.0,
+        ];
+
+        return array_merge($default, $this->options);
+    }
+
+    /**
+     * Configure HTTP request options.
+     *
+     * @param  array<string, mixed>  $options
+     */
+    public function optionsUsing(array $options): self
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+}

--- a/src/Contracts/BuildsSignature.php
+++ b/src/Contracts/BuildsSignature.php
@@ -7,6 +7,23 @@ use Psr\Http\Message\RequestInterface;
 interface BuildsSignature
 {
     /**
+     * The algorithm in ACS format.
+     */
+    public function algorithmForAcs(): string;
+
+    /**
+     * The algorithm.
+     */
+    public function algorithm(): string;
+
+    /**
+     * Get the headers for signature calculation.
+     *
+     * @return  string[]
+     */
+    public function signedHeaders(RequestInterface $request): array;
+
+    /**
      * Build the signature for the given request.
      */
     public function build(RequestInterface $request): string;

--- a/src/Middlewares/ConfigureMetadata.php
+++ b/src/Middlewares/ConfigureMetadata.php
@@ -5,6 +5,7 @@ namespace Dew\Tablestore\Middlewares;
 use Dew\Tablestore\Tablestore;
 use Dew\Tablestore\TablestoreInstance;
 use GuzzleHttp\Middleware;
+use InvalidArgumentException;
 use Psr\Http\Message\RequestInterface;
 
 class ConfigureMetadata
@@ -45,9 +46,12 @@ class ConfigureMetadata
             RequestInterface $request, array $options
         ) use ($handler, $tablestore) {
             $request = $request
-                ->withHeader('x-acs-action', $options['acs']['action'])
+                ->withHeader('x-acs-action', $options['acs']['action']
+                    ?? throw new InvalidArgumentException('API requires action name.'))
                 ->withHeader('x-acs-date', gmdate('Y-m-d\\TH:i:s\\Z'))
-                ->withHeader('x-acs-version', $options['acs']['version']);
+                ->withHeader('x-acs-version', $options['acs']['version']
+                    ?? throw new InvalidArgumentException('API requires version number.')
+                );
 
             if (is_string($tablestore->token())) {
                 $request = $request

--- a/src/Middlewares/ConfigureMetadata.php
+++ b/src/Middlewares/ConfigureMetadata.php
@@ -14,7 +14,7 @@ class ConfigureMetadata
      *
      * @return callable(callable): callable
      */
-    public static function make(Tablestore $tablestore): callable
+    public static function forOts(Tablestore $tablestore): callable
     {
         return Middleware::mapRequest(function (RequestInterface $request) use ($tablestore): RequestInterface {
             $request = $request

--- a/src/Middlewares/ConfigureMetadata.php
+++ b/src/Middlewares/ConfigureMetadata.php
@@ -39,7 +39,7 @@ class ConfigureMetadata
      *
      * @return callable(callable): callable
      */
-    public static function acs(TablestoreInstance $tablestore): callable
+    public static function forAcs(TablestoreInstance $tablestore): callable
     {
         return static fn (callable $handler): callable => static function (
             RequestInterface $request, array $options

--- a/src/Middlewares/SignRequest.php
+++ b/src/Middlewares/SignRequest.php
@@ -18,4 +18,20 @@ class SignRequest
             'x-ots-signature', $signature->build($request)
         ));
     }
+
+    /**
+     * Make a middleware to build signature for the ACS request.
+     *
+     * @return callable(callable): callable
+     */
+    public static function acs(BuildsSignature $signature, string $accessKeyId): callable
+    {
+        return Middleware::mapRequest(fn ($request) => $request->withHeader(
+            'Authorization', sprintf('%s Credential=%s,SignedHeaders=%s,Signature=%s',
+                $signature->algorithmForAcs(), $accessKeyId,
+                implode(';', $signature->signedHeaders($request)),
+                $signature->build($request)
+            ))
+        );
+    }
 }

--- a/src/Responses/Response.php
+++ b/src/Responses/Response.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Dew\Tablestore\Responses;
+
+use BadMethodCallException;
+use Dew\Tablestore\Support\Arr;
+use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
+
+/**
+ * @template TResponse of \Psr\Http\Message\ResponseInterface
+ *
+ * @mixin TResponse
+ */
+class Response
+{
+    /**
+     * The decoded data.
+     *
+     * @var array<mixed>
+     */
+    protected array $decoded;
+
+    /**
+     * Create a new response instance.
+     *
+     * @param  TResponse  $response
+     */
+    public function __construct(
+        public ResponseInterface $response
+    ) {
+        //
+    }
+
+    /**
+     * Get data with dotted notation.
+     *
+     * @return ($name is null ? array<mixed> : mixed)
+     */
+    public function json(string $name = null, mixed $default = null): mixed
+    {
+        if (! isset($this->decoded)) {
+            $data = (string) $this->response->getBody();
+            $decoded = json_decode($data, associative: true) ?? [];
+
+            if (! is_array($decoded)) {
+                throw new RuntimeException(sprintf(
+                    'Failed to decode the content [%s] as JSON data.', $data
+                ));
+            }
+
+            $this->decoded = $decoded;
+        }
+
+        return $name === null ? $this->decoded : Arr::get($this->decoded, $name, $default);
+    }
+
+    /**
+     * Get the underlying PSR7 Response instance.
+     */
+    public function toPsr7(): ResponseInterface
+    {
+        return $this->response;
+    }
+
+    /**
+     * Proxy calling to the response.
+     *
+     * @param  array<int, mixed>  $arguments
+     */
+    public function __call(string $method, array $arguments = []): mixed
+    {
+        $callback = [$this->response, $method];
+
+        if (is_callable($callback)) {
+            return call_user_func_array($callback, $arguments);
+        }
+
+        throw new BadMethodCallException(sprintf('Call to undefined method %s::%s()',
+            $this->response::class, $method
+        ));
+    }
+}

--- a/src/Support/Arr.php
+++ b/src/Support/Arr.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Dew\Tablestore\Support;
+
+class Arr
+{
+    /**
+     * Get the data with dotted notation.
+     *
+     * @param  array<mixed>  $array
+     */
+    public static function get(array $array, int|string $key, mixed $default = null): mixed
+    {
+        $key = (string) $key;
+
+        if (array_key_exists($key, $array)) {
+            return $array[$key];
+        }
+
+        if (! str_contains($key, '.')) {
+            return $array[$key] ?? $default;
+        }
+
+        foreach (explode('.', $key) as $segment) {
+            if (is_array($array) && array_key_exists($segment, $array)) {
+                $array = $array[$segment];
+            } else {
+                return $default;
+            }
+        }
+
+        return $array;
+    }
+}

--- a/src/Tablestore.php
+++ b/src/Tablestore.php
@@ -2,6 +2,7 @@
 
 namespace Dew\Tablestore;
 
+use Dew\Tablestore\Concerns\CommunicatesWithAcs;
 use Dew\Tablestore\Contracts\BuildsSignature;
 use Dew\Tablestore\Middlewares\ConfigureMetadata;
 use Dew\Tablestore\Middlewares\SignRequest;
@@ -21,27 +22,12 @@ use Psr\Http\Message\ResponseInterface;
 
 class Tablestore
 {
-    /**
-     * The signature builder.
-     */
-    protected BuildsSignature $signature;
+    use CommunicatesWithAcs;
 
     /**
      * The instance name.
      */
     protected string $instance;
-
-    /**
-     * The STS token for the access key.
-     */
-    protected string $token;
-
-    /**
-     * The HTTP request options.
-     *
-     * @var array<string, mixed>
-     */
-    protected array $options = [];
 
     /**
      * Create a Tablestore.
@@ -56,53 +42,11 @@ class Tablestore
     }
 
     /**
-     * The ACS access key ID.
-     */
-    public function accessKeyId(): string
-    {
-        return $this->accessKeyId;
-    }
-
-    /**
-     * The ACS access key secret.
-     */
-    public function accessKeySecret(): string
-    {
-        return $this->accessKeySecret;
-    }
-
-    /**
-     * The Tablestore endpoint.
-     */
-    public function endpoint(): string
-    {
-        return $this->endpoint;
-    }
-
-    /**
      * The Tablestore instance name.
      */
     public function instanceName(): string
     {
         return $this->instance;
-    }
-
-    /**
-     * The STS token for the access key.
-     */
-    public function token(): ?string
-    {
-        return $this->token ?? null;
-    }
-
-    /**
-     * Configure STS token for the access key.
-     */
-    public function tokenUsing(string $token): self
-    {
-        $this->token = $token;
-
-        return $this;
     }
 
     /**
@@ -207,46 +151,10 @@ class Tablestore
     }
 
     /**
-     * The signature builder.
+     * Create a new signature builder.
      */
-    public function signature(): BuildsSignature
+    protected function newSignature(): BuildsSignature
     {
-        return $this->signature ??= new TablestoreSignature($this->accessKeySecret);
-    }
-
-    /**
-     * Set signature builder.
-     */
-    public function signatureUsing(BuildsSignature $signature): self
-    {
-        $this->signature = $signature;
-
-        return $this;
-    }
-
-    /**
-     * The HTTP request options.
-     *
-     * @return array<string, mixed>
-     */
-    public function options(): array
-    {
-        $default = [
-            'timeout' => 2.0,
-        ];
-
-        return array_merge($default, $this->options);
-    }
-
-    /**
-     * Configure HTTP request options.
-     *
-     * @param  array<string, mixed>  $options
-     */
-    public function optionsUsing(array $options): self
-    {
-        $this->options = $options;
-
-        return $this;
+        return new TablestoreSignature($this->accessKeySecret);
     }
 }

--- a/src/Tablestore.php
+++ b/src/Tablestore.php
@@ -139,7 +139,7 @@ class Tablestore
     public function send(string $endpoint, Message $message): ResponseInterface
     {
         $handler = HandlerStack::create();
-        $handler->push(ConfigureMetadata::make($this));
+        $handler->push(ConfigureMetadata::forOts($this));
         $handler->push(SignRequest::make($this->signature()));
 
         $client = new Client(array_merge($this->options(), [

--- a/src/TablestoreInstance.php
+++ b/src/TablestoreInstance.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace Dew\Tablestore;
+
+use Dew\Tablestore\Concerns\CommunicatesWithAcs;
+use Dew\Tablestore\Contracts\BuildsSignature;
+use Dew\Tablestore\Middlewares\ConfigureMetadata;
+use Dew\Tablestore\Middlewares\SignRequest;
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use Psr\Http\Message\ResponseInterface;
+
+class TablestoreInstance
+{
+    use CommunicatesWithAcs;
+
+    /**
+     * Create a Tablestore instance client.
+     */
+    public function __construct(
+        protected string $accessKeyId,
+        protected string $accessKeySecret,
+        protected string $region
+    ) {
+        //
+    }
+
+    /**
+     * The ACS region.
+     */
+    public function region(): string
+    {
+        return $this->region;
+    }
+
+    /**
+     * The Tablestore federal endpoint.
+     *
+     * @see https://github.com/aliyun/terraform-provider-alicloud/blob/5ec9f55e1f5ee8352074e117752d434c96060f47/alicloud/connectivity/endpoint.go#L165
+     */
+    public function endpoint(): string
+    {
+        return sprintf('https://tablestore.%s.aliyuncs.com', $this->region);
+    }
+
+    /**
+     * List instances by the given criteria.
+     *
+     * @param  array{status?: string, maxResults?: int, nextToken?: string}  $criteria
+     */
+    public function all(array $criteria = []): ResponseInterface
+    {
+        return $this->send('GET', '/v2/openapi/listinstances', [
+            'query' => $criteria,
+            'acs' => [
+                'action' => 'ListInstances',
+                'version' => '2020-12-09',
+            ],
+        ]);
+    }
+
+    /**
+     * Get Tablestore instance information.
+     */
+    public function get(string $instance): ResponseInterface
+    {
+        return $this->send('GET', '/v2/openapi/getinstance', [
+            'query' => [
+                'InstanceName' => $instance,
+            ],
+            'acs' => [
+                'action' => 'GetInstance',
+                'version' => '2020-12-09',
+            ],
+        ]);
+    }
+
+    /**
+     * Create a new Tablestore instance.
+     *
+     * @param  array{
+     *   InstanceName: string,
+     *   InstanceDescription?: string,
+     *   AliasName?: string,
+     *   ClusterType?: string,
+     *   Network?: string
+     * }  $instance
+     */
+    public function create(array $instance): ResponseInterface
+    {
+        return $this->send('POST', '/v2/openapi/createinstance', [
+            'json' => $instance,
+            'acs' => [
+                'action' => 'CreateInstance',
+                'version' => '2020-12-09',
+            ],
+        ]);
+    }
+
+    /**
+     * Update an existing Tablestore instance.
+     *
+     * @param  array{
+     *   InstanceName: string,
+     *   InstanceDescription?: string,
+     *   AliasName?: string,
+     *   Network?: string
+     * }  $instance
+     */
+    public function update(array $instance): ResponseInterface
+    {
+        return $this->send('POST', '/v2/openapi/updateinstance', [
+            'json' => $instance,
+            'acs' => [
+                'action' => 'UpdateInstance',
+                'version' => '2020-12-09',
+            ],
+        ]);
+    }
+
+    /**
+     * Delete Tablestore instance.
+     */
+    public function delete(string $instance): ResponseInterface
+    {
+        return $this->send('POST', '/v2/openapi/deleteinstance', [
+            'json' => [
+                'InstanceName' => $instance,
+            ],
+            'acs' => [
+                'action' => 'DeleteInstance',
+                'version' => '2020-12-09',
+            ],
+        ]);
+    }
+
+    /**
+     * Attach tags to the resources.
+     *
+     * @param  array{
+     *   ResourceIds: string[],
+     *   ResourceType: string,
+     *   Tags: array{Key: string, Value: string}[]
+     * }  $data
+     */
+    public function tag(array $data): ResponseInterface
+    {
+        return $this->send('POST', '/v2/openapi/tagresources', [
+            'json' => $data,
+            'acs' => [
+                'action' => 'TagResources',
+                'version' => '2020-12-09',
+            ],
+        ]);
+    }
+
+    /**
+     * Attach tags to the Tablestore instances.
+     *
+     * @param  string|string[]  $instances
+     * @param  array<string, string>  $tags
+     */
+    public function tagInstance(array|string $instances, array $tags): ResponseInterface
+    {
+        $build = [];
+
+        foreach ($tags as $key => $value) {
+            $build[] = ['Key' => $key, 'Value' => $value];
+        }
+
+        return $this->tag([
+            'ResourceType' => 'INSTANCE',
+            'ResourceIds' => is_array($instances) ? $instances : [$instances],
+            'Tags' => $build,
+        ]);
+    }
+
+    /**
+     * Remove tags from the resources.
+     *
+     * @param  array{
+     *   ResourceIds: string[],
+     *   ResourceType: string,
+     *   TagKeys: string[]
+     * }  $data
+     */
+    public function untag(array $data): ResponseInterface
+    {
+        return $this->send('POST', '/v2/openapi/untagresources', [
+            'json' => $data,
+            'acs' => [
+                'action' => 'UntagResources',
+                'version' => '2020-12-09',
+            ],
+        ]);
+    }
+
+    /**
+     * Remove tags from Tablestore instances.
+     *
+     * @param  string[]|string  $instances
+     * @param  string[]|string  $tags
+     */
+    public function untagInstance(array|string $instances, array|string $tags): ResponseInterface
+    {
+        return $this->untag([
+            'ResourceType' => 'INSTANCE',
+            'ResourceIds' => is_array($instances) ? $instances : [$instances],
+            'TagKeys' => is_array($tags) ? $tags : [$tags],
+        ]);
+    }
+
+    /**
+     * Send the HTTP request.
+     *
+     * @param  array<string, mixed>  $options
+     */
+    public function send(string $method, string $endpoint, array $options = []): ResponseInterface
+    {
+        $handler = HandlerStack::create();
+        $handler->push(ConfigureMetadata::acs($this));
+        $handler->push(SignRequest::acs($this->signature(), $this->accessKeyId));
+
+        $client = new Client(array_merge($this->options(), [
+            'base_uri' => $this->endpoint(),
+            'handler' => $handler,
+        ]));
+
+        return $client->request($method, $endpoint, $options);
+    }
+
+    /**
+     * Create a new signature builder.
+     */
+    protected function newSignature(): BuildsSignature
+    {
+        return (new AcsSignature($this->accessKeySecret))->include([
+            'host', 'content-type',
+        ]);
+    }
+}

--- a/src/TablestoreInstance.php
+++ b/src/TablestoreInstance.php
@@ -6,9 +6,9 @@ use Dew\Tablestore\Concerns\CommunicatesWithAcs;
 use Dew\Tablestore\Contracts\BuildsSignature;
 use Dew\Tablestore\Middlewares\ConfigureMetadata;
 use Dew\Tablestore\Middlewares\SignRequest;
+use Dew\Tablestore\Responses\Response;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
-use Psr\Http\Message\ResponseInterface;
 
 class TablestoreInstance
 {
@@ -47,8 +47,9 @@ class TablestoreInstance
      * List instances by the given criteria.
      *
      * @param  array{status?: string, maxResults?: int, nextToken?: string}  $criteria
+     * @return \Dew\Tablestore\Responses\Response<\Psr\Http\Message\ResponseInterface>
      */
-    public function all(array $criteria = []): ResponseInterface
+    public function all(array $criteria = []): Response
     {
         return $this->send('GET', '/v2/openapi/listinstances', [
             'query' => $criteria,
@@ -61,8 +62,10 @@ class TablestoreInstance
 
     /**
      * Get Tablestore instance information.
+     *
+     * @return \Dew\Tablestore\Responses\Response<\Psr\Http\Message\ResponseInterface>
      */
-    public function get(string $instance): ResponseInterface
+    public function get(string $instance): Response
     {
         return $this->send('GET', '/v2/openapi/getinstance', [
             'query' => [
@@ -85,8 +88,9 @@ class TablestoreInstance
      *   ClusterType?: string,
      *   Network?: string
      * }  $instance
+     * @return \Dew\Tablestore\Responses\Response<\Psr\Http\Message\ResponseInterface>
      */
-    public function create(array $instance): ResponseInterface
+    public function create(array $instance): Response
     {
         return $this->send('POST', '/v2/openapi/createinstance', [
             'json' => $instance,
@@ -106,8 +110,9 @@ class TablestoreInstance
      *   AliasName?: string,
      *   Network?: string
      * }  $instance
+     * @return \Dew\Tablestore\Responses\Response<\Psr\Http\Message\ResponseInterface>
      */
-    public function update(array $instance): ResponseInterface
+    public function update(array $instance): Response
     {
         return $this->send('POST', '/v2/openapi/updateinstance', [
             'json' => $instance,
@@ -120,8 +125,10 @@ class TablestoreInstance
 
     /**
      * Delete Tablestore instance.
+     *
+     * @return \Dew\Tablestore\Responses\Response<\Psr\Http\Message\ResponseInterface>
      */
-    public function delete(string $instance): ResponseInterface
+    public function delete(string $instance): Response
     {
         return $this->send('POST', '/v2/openapi/deleteinstance', [
             'json' => [
@@ -142,8 +149,9 @@ class TablestoreInstance
      *   ResourceType: string,
      *   Tags: array{Key: string, Value: string}[]
      * }  $data
+     * @return \Dew\Tablestore\Responses\Response<\Psr\Http\Message\ResponseInterface>
      */
-    public function tag(array $data): ResponseInterface
+    public function tag(array $data): Response
     {
         return $this->send('POST', '/v2/openapi/tagresources', [
             'json' => $data,
@@ -159,8 +167,9 @@ class TablestoreInstance
      *
      * @param  string|string[]  $instances
      * @param  array<string, string>  $tags
+     * @return \Dew\Tablestore\Responses\Response<\Psr\Http\Message\ResponseInterface>
      */
-    public function tagInstance(array|string $instances, array $tags): ResponseInterface
+    public function tagInstance(array|string $instances, array $tags): Response
     {
         $build = [];
 
@@ -183,8 +192,9 @@ class TablestoreInstance
      *   ResourceType: string,
      *   TagKeys: string[]
      * }  $data
+     * @return \Dew\Tablestore\Responses\Response<\Psr\Http\Message\ResponseInterface>
      */
-    public function untag(array $data): ResponseInterface
+    public function untag(array $data): Response
     {
         return $this->send('POST', '/v2/openapi/untagresources', [
             'json' => $data,
@@ -200,8 +210,9 @@ class TablestoreInstance
      *
      * @param  string[]|string  $instances
      * @param  string[]|string  $tags
+     * @return \Dew\Tablestore\Responses\Response<\Psr\Http\Message\ResponseInterface>
      */
-    public function untagInstance(array|string $instances, array|string $tags): ResponseInterface
+    public function untagInstance(array|string $instances, array|string $tags): Response
     {
         return $this->untag([
             'ResourceType' => 'INSTANCE',
@@ -214,8 +225,9 @@ class TablestoreInstance
      * Send the HTTP request.
      *
      * @param  array<string, mixed>  $options
+     * @return \Dew\Tablestore\Responses\Response<\Psr\Http\Message\ResponseInterface>
      */
-    public function send(string $method, string $endpoint, array $options = []): ResponseInterface
+    public function send(string $method, string $endpoint, array $options = []): Response
     {
         $handler = HandlerStack::create();
         $handler->push(ConfigureMetadata::forAcs($this));
@@ -226,7 +238,7 @@ class TablestoreInstance
             'handler' => $handler,
         ]));
 
-        return $client->request($method, $endpoint, $options);
+        return new Response($client->request($method, $endpoint, $options));
     }
 
     /**

--- a/src/TablestoreInstance.php
+++ b/src/TablestoreInstance.php
@@ -10,6 +10,9 @@ use Dew\Tablestore\Responses\Response;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 
+/**
+ * @phpstan-type InstanceTag array{Key: string, Value: string}
+ */
 class TablestoreInstance
 {
     use CommunicatesWithAcs;
@@ -87,6 +90,7 @@ class TablestoreInstance
      *   AliasName?: string,
      *   ClusterType?: string,
      *   Network?: string
+     *   Tags?: InstanceTag[]
      * }  $instance
      * @return \Dew\Tablestore\Responses\Response<\Psr\Http\Message\ResponseInterface>
      */
@@ -147,7 +151,7 @@ class TablestoreInstance
      * @param  array{
      *   ResourceIds: string[],
      *   ResourceType: string,
-     *   Tags: array{Key: string, Value: string}[]
+     *   Tags: InstanceTag[]
      * }  $data
      * @return \Dew\Tablestore\Responses\Response<\Psr\Http\Message\ResponseInterface>
      */

--- a/src/TablestoreInstance.php
+++ b/src/TablestoreInstance.php
@@ -218,7 +218,7 @@ class TablestoreInstance
     public function send(string $method, string $endpoint, array $options = []): ResponseInterface
     {
         $handler = HandlerStack::create();
-        $handler->push(ConfigureMetadata::acs($this));
+        $handler->push(ConfigureMetadata::forAcs($this));
         $handler->push(SignRequest::acs($this->signature(), $this->accessKeyId));
 
         $client = new Client(array_merge($this->options(), [

--- a/tests/ArrTest.php
+++ b/tests/ArrTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Dew\Tablestore\Support\Arr;
+
+test('get gets with key', function () {
+    $data = ['foo' => 'bar'];
+    expect(Arr::get($data, 'foo'))->toBe('bar');
+});
+
+test('get gets with default value', function () {
+    $data = ['foo' => 'bar'];
+    expect(Arr::get($data, 'name'))->toBeNull();
+    expect(Arr::get($data, 'name', 'Zhineng'))->toBe('Zhineng');
+});
+
+test('get gets with dotted notation', function () {
+    $data = ['nested' => ['foo' => 'bar']];
+    expect(Arr::get($data, 'nested.foo'))->toBe('bar');
+    expect(Arr::get($data, 'nested.foo.bar'))->toBeNull();
+});
+
+test('get gets with key contains a dot', function () {
+    $data = ['nested.foo' => 'bar', 'nested' => ['foo' => 'baz']];
+    expect(Arr::get($data, 'nested.foo'))->toBe('bar');
+});
+
+test('get gets with index key', function () {
+    $data = ['foo', 'bar'];
+    expect(Arr::get($data, 0))->toBe('foo');
+    expect(Arr::get($data, 1))->toBe('bar');
+    expect(Arr::get($data, 2, 'baz'))->toBe('baz');
+});
+
+test('get gets with nested index key', function () {
+    $data = ['list' => ['foo', 'bar']];
+    expect(Arr::get($data, 'list.0'))->toBe('foo');
+    expect(Arr::get($data, 'list.1'))->toBe('bar');
+    expect(Arr::get($data, 'list.2', 'baz'))->toBe('baz');
+});

--- a/tests/ConfigureMetadataTest.php
+++ b/tests/ConfigureMetadataTest.php
@@ -5,7 +5,7 @@ use Dew\Tablestore\Tablestore;
 use GuzzleHttp\Psr7\Request;
 
 test('headers are sorted', function ($ots) {
-    $apply = ConfigureMetadata::make($ots);
+    $apply = ConfigureMetadata::forOts($ots);
     $request = $apply(fn ($request, $options) => $request)(new Request('GET', '/'), []);
     $sorted = array_keys($request->getHeaders());
     sort($sorted);
@@ -14,7 +14,7 @@ test('headers are sorted', function ($ots) {
 
 test('header sts token is missing when not provided', function () {
     $ots = new Tablestore('key', 'secret', 'https://instance.cn-hangzhou.ots.aliyuncs.com');
-    $apply = ConfigureMetadata::make($ots);
+    $apply = ConfigureMetadata::forOts($ots);
     $request = $apply(fn ($request, $options) => $request)(new Request('GET', '/'), []);
     expect($request->hasHeader('x-ots-ststoken'))->toBeFalse();
 });
@@ -22,7 +22,7 @@ test('header sts token is missing when not provided', function () {
 test('header has sts token when provided', function () {
     $ots = new Tablestore('key', 'secret', 'https://instance.cn-hangzhou.ots.aliyuncs.com');
     $ots->tokenUsing('token');
-    $apply = ConfigureMetadata::make($ots);
+    $apply = ConfigureMetadata::forOts($ots);
     $request = $apply(fn ($request, $options) => $request)(new Request('GET', '/'), []);
     expect($request->hasHeader('x-ots-ststoken'))->toBeTrue()
         ->and($request->getHeaderLine('x-ots-ststoken'))->toBe('token');

--- a/tests/ConfigureMetadataTest.php
+++ b/tests/ConfigureMetadataTest.php
@@ -2,6 +2,7 @@
 
 use Dew\Tablestore\Middlewares\ConfigureMetadata;
 use Dew\Tablestore\Tablestore;
+use Dew\Tablestore\TablestoreInstance;
 use GuzzleHttp\Psr7\Request;
 
 test('ots headers are sorted', function ($ots) {
@@ -26,6 +27,48 @@ test('ots header has sts token when provided', function () {
     $request = $apply(fn ($request, $options) => $request)(new Request('GET', '/'), []);
     expect($request->hasHeader('x-ots-ststoken'))->toBeTrue()
         ->and($request->getHeaderLine('x-ots-ststoken'))->toBe('token');
+});
+
+test('acs header token is missing when not provided', function () {
+    $ots = new TablestoreInstance('key', 'secret', 'us-west-1');
+    $applyMiddleware = ConfigureMetadata::forAcs($ots);
+    $request = new Request('GET', '/');
+    $options = ['acs' => ['action' => '', 'version' => '']];
+    $handler = fn ($request, $options) => $request;
+    $request = $applyMiddleware($handler)($request, $options);
+    expect($request->hasheader('x-acs-security-token'))->toBeFalse();
+});
+
+test('acs header has token when provided', function () {
+    $ots = new TablestoreInstance('key', 'secret', 'us-west-1');
+    $ots->tokenUsing('token');
+    $applyMiddleware = ConfigureMetadata::forAcs($ots);
+    $request = new Request('GET', '/');
+    $options = ['acs' => ['action' => '', 'version' => '']];
+    $handler = fn ($request, $options) => $request;
+    $request = $applyMiddleware($handler)($request, $options);
+    expect($request->getHeaderLine('x-acs-accesskey-id'))->toBe('key')
+        ->and($request->getHeaderLine('x-acs-security-token'))->toBe('token');
+});
+
+test('acs requires action', function () {
+    $ots = new TablestoreInstance('key', 'secret', 'us-west-1');
+    $applyMiddleware = ConfigureMetadata::forAcs($ots);
+    $request = new Request('GET', '/');
+    $options = ['acs' => ['version' => '']];
+    $handler = fn ($request, $options) => $request;
+    expect(fn () => $applyMiddleware($handler)($request, $options))
+        ->toThrow(InvalidArgumentException::class, 'API requires action name.');
+});
+
+test('acs requires version', function () {
+    $ots = new TablestoreInstance('key', 'secret', 'us-west-1');
+    $applyMiddleware = ConfigureMetadata::forAcs($ots);
+    $request = new Request('GET', '/');
+    $options = ['acs' => ['action' => '']];
+    $handler = fn ($request, $options) => $request;
+    expect(fn () => $applyMiddleware($handler)($request, $options))
+        ->toThrow(InvalidArgumentException::class, 'API requires version number.');
 });
 
 dataset('tablestore instances', [

--- a/tests/ConfigureMetadataTest.php
+++ b/tests/ConfigureMetadataTest.php
@@ -4,7 +4,7 @@ use Dew\Tablestore\Middlewares\ConfigureMetadata;
 use Dew\Tablestore\Tablestore;
 use GuzzleHttp\Psr7\Request;
 
-test('headers are sorted', function ($ots) {
+test('ots headers are sorted', function ($ots) {
     $apply = ConfigureMetadata::forOts($ots);
     $request = $apply(fn ($request, $options) => $request)(new Request('GET', '/'), []);
     $sorted = array_keys($request->getHeaders());
@@ -12,14 +12,14 @@ test('headers are sorted', function ($ots) {
     expect(array_keys($request->getHeaders()))->toBe($sorted);
 })->with('tablestore instances');
 
-test('header sts token is missing when not provided', function () {
+test('ots header sts token is missing when not provided', function () {
     $ots = new Tablestore('key', 'secret', 'https://instance.cn-hangzhou.ots.aliyuncs.com');
     $apply = ConfigureMetadata::forOts($ots);
     $request = $apply(fn ($request, $options) => $request)(new Request('GET', '/'), []);
     expect($request->hasHeader('x-ots-ststoken'))->toBeFalse();
 });
 
-test('header has sts token when provided', function () {
+test('ots header has sts token when provided', function () {
     $ots = new Tablestore('key', 'secret', 'https://instance.cn-hangzhou.ots.aliyuncs.com');
     $ots->tokenUsing('token');
     $apply = ConfigureMetadata::forOts($ots);

--- a/tests/Integration/InstanceTest.php
+++ b/tests/Integration/InstanceTest.php
@@ -2,8 +2,7 @@
 
 test('list lists all instances', function () {
     $response = instance()->all();
-    $data = json_decode($response->getBody()->getContents(), associative: true);
-    expect($data)->toBeArray()->toHaveKeys(['TotalCount', 'NextToken', 'Instances']);
+    expect($response->json())->toHaveKeys(['TotalCount', 'NextToken', 'Instances']);
 })->skip(! integrationTestEnabled(), 'integration test not enabled');
 
 test('create creates new instance', function () {
@@ -15,19 +14,16 @@ test('create creates new instance', function () {
         'Network' => 'NORMAL',
     ]);
 
-    $data = json_decode($response->getBody()->getContents(), associative: true);
-    expect($data)->toBeArray()->toHaveKey('RequestId');
+    expect($response->json('RequestId'))->toBeString()->not->toBeEmpty();
 
     return $instance;
 })->skip(! integrationTestEnabled(), 'integration test not enabled');
 
 test('get retrieves instance information', function (string $instance) {
     $response = instance()->get($instance);
-    $data = json_decode($response->getBody()->getContents(), associative: true);
-    expect($data)->toBeArray()->toHaveKeys(['InstanceName', 'InstanceDescription', 'AliasName'])
-        ->and($data['InstanceName'])->toBe($instance)
-        ->and($data['InstanceDescription'])->toBe('bar')
-        ->and($data['AliasName'])->toBe('foo');
+    expect($response->json('InstanceName'))->toBe($instance)
+        ->and($response->json('InstanceDescription'))->toBe('bar')
+        ->and($response->json('AliasName'))->toBe('foo');
 })->depends('create creates new instance')
     ->skip(! integrationTestEnabled(), 'integration test not enabled');
 
@@ -36,38 +32,28 @@ test('update updates instance', function (string $instance) {
         'InstanceName' => $instance,
         'InstanceDescription' => 'updated',
     ]);
-    $data = json_decode($response->getBody()->getContents(), associative: true);
-    expect($data)->toBeArray()->toHaveKey('RequestId');
+    expect($response->json('RequestId'))->toBeString()->not->toBeEmpty();
 })->depends('create creates new instance')
     ->skip(! integrationTestEnabled(), 'integration test not enabled');
 
 test('tag attaches tags to instance', function (string $instance) {
     $response = instance()->tagInstance($instance, ['Test' => 'true']);
-    $data = json_decode($response->getBody()->getContents(), associative: true);
-    expect($data)->toBeArray()->toHaveKey('RequestId');
+    expect($response->json('RequestId'))->toBeString()->not->toBeEmpty();
 
     $response = instance()->get($instance);
-    $data = json_decode($response->getBody()->getContents(), associative: true);
-    expect($data)->toBeArray()->toHaveKey('Tags')
-        ->and($data['Tags'])->toBe([['Key' => 'Test', 'Value' => 'true']]);
+    expect($response->json('Tags'))->toBe([['Key' => 'Test', 'Value' => 'true']]);
 })->depends('create creates new instance')
     ->skip(! integrationTestEnabled(), 'integration test not enabled');
 
 test('untag removes tags from instance', function (string $instance) {
     $response = instance()->untagInstance($instance, 'Test');
-    $data = json_decode($response->getBody()->getContents(), associative: true);
-    expect($data)->toBeArray()->toHaveKey('RequestId');
-
-    $response = instance()->get($instance);
-    $data = json_decode($response->getBody()->getContents(), associative: true);
-    expect($data)->toBeArray()->toHaveKey('Tags')
-        ->and($data['Tags'])->toBe([]);
+    expect($response->json('RequestId'))->toBeString()->not->toBeEmpty()
+        ->and(instance()->get($instance)->json('Tags'))->toBe([]);
 })->depends('create creates new instance')
     ->skip(! integrationTestEnabled(), 'integration test not enabled');
 
 test('delete deletes the instance', function (string $instance) {
     $response = instance()->delete($instance);
-    $data = json_decode($response->getBody()->getContents(), associative: true);
-    expect($data)->toBeArray()->toHaveKey('RequestId');
+    expect($response->json('RequestId'))->toBeString()->not->toBeEmpty();
 })->depends('create creates new instance')
     ->skip(! integrationTestEnabled(), 'integration test not enabled');

--- a/tests/Integration/InstanceTest.php
+++ b/tests/Integration/InstanceTest.php
@@ -1,0 +1,73 @@
+<?php
+
+test('list lists all instances', function () {
+    $response = instance()->all();
+    $data = json_decode($response->getBody()->getContents(), associative: true);
+    expect($data)->toBeArray()->toHaveKeys(['TotalCount', 'NextToken', 'Instances']);
+})->skip(! integrationTestEnabled(), 'integration test not enabled');
+
+test('create creates new instance', function () {
+    $response = instance()->create([
+        'InstanceName' => $instance = 'test'.time(),
+        'InstanceDescription' => 'bar',
+        'AliasName' => 'foo',
+        'ClusterType' => 'SSD',
+        'Network' => 'NORMAL',
+    ]);
+
+    $data = json_decode($response->getBody()->getContents(), associative: true);
+    expect($data)->toBeArray()->toHaveKey('RequestId');
+
+    return $instance;
+})->skip(! integrationTestEnabled(), 'integration test not enabled');
+
+test('get retrieves instance information', function (string $instance) {
+    $response = instance()->get($instance);
+    $data = json_decode($response->getBody()->getContents(), associative: true);
+    expect($data)->toBeArray()->toHaveKeys(['InstanceName', 'InstanceDescription', 'AliasName'])
+        ->and($data['InstanceName'])->toBe($instance)
+        ->and($data['InstanceDescription'])->toBe('bar')
+        ->and($data['AliasName'])->toBe('foo');
+})->depends('create creates new instance')
+    ->skip(! integrationTestEnabled(), 'integration test not enabled');
+
+test('update updates instance', function (string $instance) {
+    $response = instance()->update([
+        'InstanceName' => $instance,
+        'InstanceDescription' => 'updated',
+    ]);
+    $data = json_decode($response->getBody()->getContents(), associative: true);
+    expect($data)->toBeArray()->toHaveKey('RequestId');
+})->depends('create creates new instance')
+    ->skip(! integrationTestEnabled(), 'integration test not enabled');
+
+test('tag attaches tags to instance', function (string $instance) {
+    $response = instance()->tagInstance($instance, ['Test' => 'true']);
+    $data = json_decode($response->getBody()->getContents(), associative: true);
+    expect($data)->toBeArray()->toHaveKey('RequestId');
+
+    $response = instance()->get($instance);
+    $data = json_decode($response->getBody()->getContents(), associative: true);
+    expect($data)->toBeArray()->toHaveKey('Tags')
+        ->and($data['Tags'])->toBe([['Key' => 'Test', 'Value' => 'true']]);
+})->depends('create creates new instance')
+    ->skip(! integrationTestEnabled(), 'integration test not enabled');
+
+test('untag removes tags from instance', function (string $instance) {
+    $response = instance()->untagInstance($instance, 'Test');
+    $data = json_decode($response->getBody()->getContents(), associative: true);
+    expect($data)->toBeArray()->toHaveKey('RequestId');
+
+    $response = instance()->get($instance);
+    $data = json_decode($response->getBody()->getContents(), associative: true);
+    expect($data)->toBeArray()->toHaveKey('Tags')
+        ->and($data['Tags'])->toBe([]);
+})->depends('create creates new instance')
+    ->skip(! integrationTestEnabled(), 'integration test not enabled');
+
+test('delete deletes the instance', function (string $instance) {
+    $response = instance()->delete($instance);
+    $data = json_decode($response->getBody()->getContents(), associative: true);
+    expect($data)->toBeArray()->toHaveKey('RequestId');
+})->depends('create creates new instance')
+    ->skip(! integrationTestEnabled(), 'integration test not enabled');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,6 +2,7 @@
 
 use Dew\Tablestore\Builder;
 use Dew\Tablestore\Tablestore;
+use Dew\Tablestore\TablestoreInstance;
 use Protos\ColumnPaginationFilter;
 use Protos\ComparatorType;
 use Protos\CompositeColumnValueFilter;
@@ -98,6 +99,25 @@ function tablestore(): Tablestore
     $tablestore = new Tablestore(
         getenv('ACS_ACCESS_KEY_ID'), getenv('ACS_ACCESS_KEY_SECRET'),
         getenv('TS_ENDPOINT'), getenv('TS_INSTANCE')
+    );
+
+    $token = getenv('ACS_STS_TOKEN');
+
+    if (is_string($token) && $token !== '') {
+        $tablestore->tokenUsing($token);
+    }
+
+    return $tablestore;
+}
+
+/**
+ * Make a Tablestore instance client from environment.
+ */
+function instance(): TablestoreInstance
+{
+    $tablestore = new TablestoreInstance(
+        getenv('ACS_ACCESS_KEY_ID'), getenv('ACS_ACCESS_KEY_SECRET'),
+        getenv('ACS_DEFAULT_REGION')
     );
 
     $token = getenv('ACS_STS_TOKEN');

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Dew\Tablestore\Responses\Response;
+use GuzzleHttp\Psr7\Response as Psr7Response;
+
+test('json decodes response body', function () {
+    $response = new Response(new Psr7Response(body: json_encode(['foo' => 'bar'])));
+    expect($response->json())->toBe(['foo' => 'bar']);
+});
+
+test('json retrieves with dotted notation', function () {
+    $response = new Response(new Psr7Response(body: json_encode(['foo' => 'bar'])));
+    expect($response->json('foo'))->toBe('bar');
+});
+
+test('json retrieves with default value', function () {
+    $response = new Response(new Psr7Response(body: json_encode(['foo' => 'bar'])));
+    expect($response->json('name', 'Zhineng'))->toBe('Zhineng');
+});
+
+test('json decodes with empty data', function () {
+    $response = new Response(new Psr7Response);
+    expect($response->json())->toBe([]);
+});
+
+test('json decodes with non-json data', function () {
+    $response = new Response(new Psr7Response(body: '1'));
+    expect(fn () => $response->json())
+        ->toThrow(RuntimeException::class, 'Failed to decode the content [1] as JSON data.');
+});
+
+test('method redirection to psr7 response', function () {
+    $response = new Response(new Psr7Response(body: json_encode(['foo' => 'bar'])));
+    expect($response->getStatusCode())->toBe(200);
+});


### PR DESCRIPTION
The APIs are not officially documented on Alibaba Cloud, and we made it happen through the reference on [Alicloud Terraform Repo](https://github.com/aliyun/terraform-provider-alicloud/blob/a0148f20da340757d55847d617fb298e776aa48c/alicloud/resource_alicloud_ots_instance.go), Tablestore GO SDK, an incomplete [Tablestore 20201209 API Tea file](https://github.com/aliyun/alibabacloud-sdk/blob/817f94cb7362186e73e2e26ddba82af98e4948a5/tablestore-20201209/main.tea), more importantly, a little bit of luck.

The arguments for each API have already been type-hinted as much as I could, feel free to check out the source code to find out what more arguments you could pass to the remote server to achieve more with a single request.

### Initialize Client

Unlike table management, we have to initialize another Tablestore client to instance operations. The client accepts the API credentials and a region where you'd like the operation to apply.

```php
$instances = new TablestoreInstance('key', 'secret', 'region');
```

### List Instances

You could filter instances by status or retrieve them in pagination, or you could also leave them behind and list instances without any arguments:

```php
$instances->all();
```

### Create Instance

The required argument to create a new Tablestore instance is an instance name. You could also specify the instance description, alias name or attach tags to the instance.

```php
$instances->create([
    'InstanceName' => 'dew',
]);
```

### Retrieve Instance Information

The instance has many critical information you could check against, such as the running status, creation time, network information, and so much more.

```php
$instances->get('dew');
```

### Update Instance

To modify an existing Tablestore instance, all you need is to provide the data you want to update and the name of the instance. The response contains only a request ID.

```php
$instances->update([
    'InstanceName' => 'dew',
    'InstanceDescription' => 'Tablestore is awesome.',
]);
```

### Delete Instance

Before destroying a Tablestore instance, ensure that you have deleted all tables and provide an instance name:

```php
$instances->delete('dew');
```

### Instance Tags

Tablestore has dedicated APIs to manage instance tags. To attach a new tag to the instance:

```php
$instances->tagInstance('dew', ['Created' => 'Zhineng']);
```

You may want to attach the tag to multiple instances, the first argument accepts a list of instance names you would like the tags to be attached to:

```php
$instances->tagInstance(['dew', 'another-instance'], ['Created' => 'Zhineng']);
```

You may need to remove the tags from instances. All arguments support a list to handle multiple resources. You could remove single tag from multiple instances or remove multiple tags from multiple instances.

```php
$instances->untagInstance('dew', 'Created');
```
